### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ CXXFLAGS:=-O3 -ffastmath -march=native -ggdb3
 TP?=DriverCpp
 
 #the path of ROPTLIB
-ROOTPATH = /home/whuang/Documents/ROPTLIB
+ROOTPATH = ROOTPATH:=$(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
 # set the path of Julia
 JULIA_DIR:=/home/whuang/Documents/julia


### PR DESCRIPTION
The make file in master contains a reference to /home/whuang/Documents/. An old version used the following line ROOTPATH:=$(dir $(realpath $(firstword $(MAKEFILE_LIST)))), which allowed it to run in other computers.